### PR TITLE
Lottery copy and scrape button and Evil copy changes

### DIFF
--- a/src/app/evil-address/page.tsx
+++ b/src/app/evil-address/page.tsx
@@ -61,7 +61,7 @@ function ScrapeAndRollOver({
             "px-[8px] py-[4px] rounded-[6px]",
           )}
         >
-          <HoverTextAnimation.Fading text="Scrape & Roll Over" />{" "}
+          <HoverTextAnimation.Fading text="Scrape and Roll-Over To Next Jackpot" />{" "}
           {/* <Tooltip
             trigger={<PiInfoDuotone />}
             positionClassName="absolute top-[calc(100%_+_8px)] right-0"

--- a/src/app/lottery/page.tsx
+++ b/src/app/lottery/page.tsx
@@ -350,7 +350,10 @@ export default function LotteryPage() {
                   loading={pruneLoading}
                   disabled={fuelCellsWon < 1 || !account.isConnected}
                   loadingText={`${pruneBatch.from}-${pruneBatch.to}/${pruneBatch.total}`}
-                  className={cn("text-[24px]", Gradients.blueToRed)}
+                  className={cn(
+                    "text-[24px] border-[1px] border-agyellow ",
+                    Gradients.blueToRed,
+                  )}
                 >
                   <motion.div
                     variants={{

--- a/src/app/lottery/page.tsx
+++ b/src/app/lottery/page.tsx
@@ -192,7 +192,7 @@ export default function LotteryPage() {
                 "text-[32px] leading-[32px] lg:text-[64px] lg:leading-[64px] font-sans font-extrabold",
               )}
             >
-              Check To See If You've Won!
+              Check To See If You&apos;ve Won!
               <PiArrowFatDownFill className="lg:-rotate-90 text-[32px] lg:text-[72px] font-extrabold inline mb-2 ml-[20px]" />
             </h1>
           </div>

--- a/src/app/lottery/page.tsx
+++ b/src/app/lottery/page.tsx
@@ -13,6 +13,7 @@ import {
   PiInfoDuotone,
   PiTrophyDuotone,
   PiWrenchDuotone,
+  PiArrowFatDownFill,
 } from "react-icons/pi";
 import { formatUnits } from "viem";
 import { AnimatePresence, motion } from "framer-motion";
@@ -179,7 +180,7 @@ export default function LotteryPage() {
         <div className="flex flex-col gap-[8px] w-full lg:max-w-[40vw]">
           <div
             className={cn(
-              "flex flex-col justify-start items-start gap-[8px]",
+              "flex flex-row justify-start items-center gap-[8px]",
               "p-[8px] rounded-[6px]",
               "bg-agblack/30 backdrop-blur-lg",
               "text-agwhite",
@@ -191,8 +192,8 @@ export default function LotteryPage() {
                 "text-[32px] leading-[32px] lg:text-[64px] lg:leading-[64px] font-sans font-extrabold",
               )}
             >
-              Congratulations!
-              <br /> Scrape your winnings!
+              Check To See If You've Won!
+              <PiArrowFatDownFill className="lg:-rotate-90 text-[32px] lg:text-[72px] font-extrabold inline mb-2 ml-[20px]" />
             </h1>
           </div>
           <div className="grid grid-flow-row md:grid-flow-col place-items-center gap-2 w-full">
@@ -256,43 +257,54 @@ export default function LotteryPage() {
                 "relative",
               )}
             >
-              <p className="text-agwhite text-[32px] leading-[32px] font-sans w-full">
-                {Number(formatUnits(BigInt(lotteryPayout), 18)).toLocaleString(
-                  "en-US",
-                )}
-              </p>
-              <div className="flex flex-col justify-end items-end gap-[8px]">
-                <motion.div
-                  initial="initial"
-                  whileHover="hover"
-                  className={cn(
-                    Gradients.lightBlue,
-                    Shapes.pill,
-                    "text-agblack font-semibold font-general-sans",
-                  )}
-                >
-                  <Image
-                    src={IMAGEKIT_ICONS.PILL_DARK_X_CLAIMED}
-                    alt="Fuel Cell"
-                    width={24}
-                    height={24}
-                    className="w-[24px] h-[24px] rounded-full"
-                  />
-                  <HoverTextAnimation.Fading text="Dark Matter" />
-                </motion.div>
+              <div className="flex flex-col justify-end items-center gap-[8px]">
+                <div className="flex justify-around items-center w-full">
+                  <p className="text-agwhite text-[32px] leading-[32px] font-sans">
+                    {Number(
+                      formatUnits(BigInt(lotteryPayout), 18),
+                    ).toLocaleString("en-US")}
+                  </p>
+                  <motion.div
+                    initial="initial"
+                    whileHover="hover"
+                    className={cn(
+                      Gradients.lightBlue,
+                      Shapes.pill,
+                      "text-agblack font-semibold font-general-sans",
+                    )}
+                  >
+                    <Image
+                      src={IMAGEKIT_ICONS.PILL_DARK_X_CLAIMED}
+                      alt="Fuel Cell"
+                      width={24}
+                      height={24}
+                      className="w-[24px] h-[24px] rounded-full"
+                    />
+                    <HoverTextAnimation.Fading text="Dark Matter" />
+                  </motion.div>
+                </div>
                 <div
                   onMouseEnter={() => setFuelCellsInfoModal(true)}
                   onMouseLeave={() => setFuelCellsInfoModal(false)}
-                  className="flex justify-center items-center gap-[4px] text-[12px] leading-[12px] font-general-sans font-semibold uppercase"
+                  className="flex flex-col justify-center items-center gap-[8px] text-[12px] leading-[12px] font-general-sans font-semibold uppercase h-[72px]"
                 >
-                  <PiTrophyDuotone className="text-[16px]" />
-                  <span>{fuelCellsWon} Fuel cells won</span>
+                  <div className="flex justify-center items-center gap-[8px]">
+                    <PiTrophyDuotone className="text-[20px]" />
+                    <h3 className="uppercase font-sans tracking-widest text-[16px]">
+                      Total Fuel Cells Won:
+                    </h3>
+                  </div>
+
+                  <p className="font-general-sans font-bold text-[32px]">
+                    {fuelCellsWon}
+                  </p>
+                  {/* <span> Fuel cells won</span> */}
                   {/* <PiInfoDuotone className="text-[16px]" /> */}
                   {/* hidden for a while since implementation is underway  */}
                   {/* <AnimatePresence>
                     {fuelCellsInfoModalOpening && (
                       <motion.div
-                        initial={{ opacity: 0 }}
+                      initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
                         transition={{ duration: 0.2 }}
@@ -302,11 +314,11 @@ export default function LotteryPage() {
                         )}
                       >
                         <div className="flex flex-col justify-center items-center gap-[8px] text-[16px] leading-[16px] py-[8px] px-[16px] rounded-[inherit] bg-agblack normal-case font-normal">
-                          <p className="text-center text-[14px]">
+                        <p className="text-center text-[14px]">
                             Your Fuel cells winnings in different lotteries
                           </p>
                           <div className="grid grid-flow-col gap-[8px] px-[8px] w-full">
-                            {Object.keys(
+                          {Object.keys(
                               LotteryAdditionalInfo.lottriesWinnings,
                             ).map((key) => (
                               <div
@@ -315,50 +327,53 @@ export default function LotteryPage() {
                               >
                                 <span className="uppercase text-[12px] font-normal">
                                   {key}
-                                </span>
-                                <span className="font-bold">
+                                  </span>
+                                  <span className="font-bold">
                                   {
                                     LotteryAdditionalInfo.lottriesWinnings[
                                       key as keyof typeof LotteryAdditionalInfo.lottriesWinnings
                                     ]
-                                  }
-                                </span>
-                              </div>
-                            ))}
-                          </div>
+                                    }
+                                    </span>
+                                    </div>
+                                    ))}
+                                    </div>
                         </div>
-                      </motion.div>
+                        </motion.div>
                     )}
-                  </AnimatePresence> */}
+                    </AnimatePresence> */}
                 </div>
+                <Button
+                  onClick={handlePruneWinnings}
+                  initial="initial"
+                  whileHover="hover"
+                  loading={pruneLoading}
+                  disabled={fuelCellsWon < 1 || !account.isConnected}
+                  loadingText={`${pruneBatch.from}-${pruneBatch.to}/${pruneBatch.total}`}
+                  className={cn("text-[16px]", Gradients.blueToRed)}
+                >
+                  <motion.div
+                    variants={{
+                      initial: { rotate: 0 },
+                      hover: {
+                        rotate: [
+                          0, -10, -10, -10, -20, -20, -20, -30, -30, -30, 0,
+                        ],
+                        transition: { duration: 1 },
+                      },
+                    }}
+                    className="origin-top-right"
+                  >
+                    <PiWrenchDuotone />
+                  </motion.div>
+                  {fuelCellsWon < 1 || !account.isConnected ? (
+                    "Scrape"
+                  ) : (
+                    <HoverTextAnimation.RollingIn text="Scrape" />
+                  )}
+                </Button>
               </div>
             </div>
-            <Button
-              onClick={handlePruneWinnings}
-              initial="initial"
-              whileHover="hover"
-              loading={pruneLoading}
-              disabled={fuelCellsWon < 1 || !account.isConnected}
-              loadingText={`${pruneBatch.from}-${pruneBatch.to}/${pruneBatch.total}`}
-            >
-              <motion.div
-                variants={{
-                  initial: { rotate: 0 },
-                  hover: {
-                    rotate: [0, -10, -10, -10, -20, -20, -20, -30, -30, -30, 0],
-                    transition: { duration: 1 },
-                  },
-                }}
-                className="origin-top-right"
-              >
-                <PiWrenchDuotone />
-              </motion.div>
-              {fuelCellsWon < 1 || !account.isConnected ? (
-                "Scrape"
-              ) : (
-                <HoverTextAnimation.RollingIn text="Scrape" />
-              )}
-            </Button>
           </form>
           <div
             className={cn(

--- a/src/app/lottery/page.tsx
+++ b/src/app/lottery/page.tsx
@@ -350,7 +350,7 @@ export default function LotteryPage() {
                   loading={pruneLoading}
                   disabled={fuelCellsWon < 1 || !account.isConnected}
                   loadingText={`${pruneBatch.from}-${pruneBatch.to}/${pruneBatch.total}`}
-                  className={cn("text-[16px]", Gradients.blueToRed)}
+                  className={cn("text-[24px]", Gradients.blueToRed)}
                 >
                   <motion.div
                     variants={{

--- a/src/lib/tailwindClassCombinators.ts
+++ b/src/lib/tailwindClassCombinators.ts
@@ -6,6 +6,8 @@ export class Gradients {
 
   static redToBlue = "bg-gradient-to-tr from-brred to-brblue";
 
+  static blueToRed = "bg-gradient-to-r from-brblue to-brred";
+
   static tableBlue = "bg-gradient-to-b from-[#0A1133] to-[#142266]";
 
   static lightBlue = "bg-gradient-to-b from-[#B4EBF8] to-[#789DFA]";


### PR DESCRIPTION
Change Summary:
- On Lottery Page - change copy from ""Congratulations, scrape your winnings!"" To ""Check To See If You've Won!"" with a giant arrow (same size as the word 'Winnings' pointing to the box that winnings would be in. Box should also be same height as background behind the copy
"Box" meaning the Dark Matter one and the Winning Box should be same size

- Scrape button should be same size as countdown box or whatever suits more. Something that makes the "scrape" button jump off the page. (https://beta.agproject.io/lottery)

- On "Scrape" button, header should read "Scrape and Roll-Over To Next Jackpot" (Evil Page)