### PR TITLE
Added a translucent background to increase visibility of max fuel cells

### DIFF
--- a/src/app/vaporize/page.tsx
+++ b/src/app/vaporize/page.tsx
@@ -224,7 +224,7 @@ export default function UnwrapPage() {
                         <HoverTextAnimation.Fading text="Fuel&nbsp;Cells" />
                       </span>
                     </motion.div>
-                    <p className=" text-s font-semibold my-3 flex items-start gap-x-1 bg-opacity-[30%] bg-agblack px-4 py-2 rounded-lg">
+                    <p className=" text-s font-semibold my-3 flex items-start gap-x-1 bg-opacity-[8%] bg-agyellow px-4 py-2 rounded-lg">
                       Max:{" "}
                       <span className="text-agyellow font-bold flex items-center gap-x-1">
                         {dataLoading ? (

--- a/src/app/vaporize/page.tsx
+++ b/src/app/vaporize/page.tsx
@@ -190,7 +190,6 @@ export default function UnwrapPage() {
                     Gradients.tableBlue,
                     Shapes.dataCard,
                     "border-[1px] border-agyellow",
-                    // "grid grid-flow-col gap-[8px]",
                     "font-extrabold",
                     "w-full",
                     "flex justify-between items-center gap-[8px]",
@@ -224,7 +223,7 @@ export default function UnwrapPage() {
                         <HoverTextAnimation.Fading text="Fuel&nbsp;Cells" />
                       </span>
                     </motion.div>
-                    <p className=" text-s font-semibold my-3 flex items-start gap-x-1 bg-opacity-[8%] bg-agyellow px-4 py-2 rounded-lg">
+                    <p className="text-s font-semibold my-3 flex items-start gap-x-1 bg-opacity-[8%] bg-agyellow px-4 py-2 rounded-lg">
                       Max:{" "}
                       <span className="text-agyellow font-bold flex items-center gap-x-1">
                         {dataLoading ? (

--- a/src/app/vaporize/page.tsx
+++ b/src/app/vaporize/page.tsx
@@ -163,7 +163,7 @@ export default function UnwrapPage() {
           <h1
             className={cn(
               Gradients.whiteGradientText,
-              "text-[64px] leading-[64px] font-sans font-extrabold",
+              "text-[64px] leading-[64px] font-sans font-extrabold p-2",
             )}
           >
             Vaporize
@@ -197,7 +197,7 @@ export default function UnwrapPage() {
                   )}
                 >
                   <Input
-                    className="w-[10ch]"
+                    className="w-[10ch] !text-[16px] md:!text-[32px]"
                     inputValue={inputValue}
                     setInputValue={setInputValue}
                     max={totalFuelCells}

--- a/src/app/vaporize/page.tsx
+++ b/src/app/vaporize/page.tsx
@@ -190,10 +190,10 @@ export default function UnwrapPage() {
                     Gradients.tableBlue,
                     Shapes.dataCard,
                     "border-[1px] border-agyellow",
-                    "grid grid-flow-col gap-[8px]",
+                    // "grid grid-flow-col gap-[8px]",
                     "font-extrabold",
                     "w-full",
-                    "flex justify-between items-center",
+                    "flex justify-between items-center gap-[8px]",
                   )}
                 >
                   <Input
@@ -210,7 +210,7 @@ export default function UnwrapPage() {
                       className={cn(
                         Gradients.lightBlue,
                         Shapes.pill,
-                        "grid grid-cols-[24px_auto]",
+                        "grid grid-cols-[80px_auto]",
                       )}
                     >
                       <Image
@@ -224,7 +224,7 @@ export default function UnwrapPage() {
                         <HoverTextAnimation.Fading text="Fuel&nbsp;Cells" />
                       </span>
                     </motion.div>
-                    <p className="text-xs font-semibold mt-2 flex items-center gap-x-1">
+                    <p className=" text-s font-semibold my-3 flex items-start gap-x-1 bg-opacity-[30%] bg-agblack px-4 py-2 rounded-lg">
                       Max:{" "}
                       <span className="text-agyellow font-bold flex items-center gap-x-1">
                         {dataLoading ? (


### PR DESCRIPTION
- On the "Max: _ Fuel Cells" copy, please increase size substantially or replace: GOAL is to make much more visible
- added a yellow translucent background to max fuel cells line.
- Edited font size of input to fit mobile screens
- added padding to "Vaporize" to better UI